### PR TITLE
fixed build errors

### DIFF
--- a/contrib/Graphics/MesaDemos/samples/overlay.c
+++ b/contrib/Graphics/MesaDemos/samples/overlay.c
@@ -36,9 +36,7 @@
 
 
 enum {
-#ifndef MONA
     NORMAL = 0,
-#endif
     WEIRD = 1
 };
 

--- a/contrib/Graphics/MesaDemos/samples/star.c
+++ b/contrib/Graphics/MesaDemos/samples/star.c
@@ -34,9 +34,7 @@
 #endif
 
 enum {
-#ifndef MONA
     NORMAL = 0,
-#endif
     WEIRD = 1
 };
 

--- a/contrib/Net/curl/Makefile.mona
+++ b/contrib/Net/curl/Makefile.mona
@@ -15,7 +15,7 @@ TOP_CSOURCES= file.c timeval.c base64.c hostip.c progress.c formdata.c cookie.c 
 
 CSOURCES = $(TOP_CSOURCES)
 
-CFLAGS+=-DHAVE_CONFIG_H -DCURL_DISABLE_FILE=1 -DCURL_DISABLE_TFTP=1
+CFLAGS+=-DHAVE_CONFIG_H -DCURL_DISABLE_FILE=1 -DCURL_DISABLE_TFTP=1 -UWIN32 -U_WIN32 -U__WIN32__
 
 OBJECTS = $(SOURCES:.cpp=.o) $(CSOURCES:.c=.o)
 INCLUDE = -I../include/curl -I../include -I. -I$(INCDIR)/ -I$(INCDIR)/monalibc -I$(INCDIR)/pixman-1

--- a/mona/core/monalibc/src.inc
+++ b/mona/core/monalibc/src.inc
@@ -12,6 +12,7 @@ SOURCES = assert/assert.c ctype/isalnum.c ctype/isalpha.c ctype/isascii.c \
       math/newlib/sf_sqrt.c math/newlib/sf_fmod.c math/newlib/sf_atan2.c math/newlib/sf_tan.c  math/newlib/s_lround.c math/newlib/s_nan.c \
       math/newlib/sf_atangent.c math/newlib/sf_frexp.c math/newlib/sf_ispos.c math/newlib/sf_ldexp.c math/newlib/sf_numtest.c \
       math/newlib/s_mathcnst.c math/newlib/ffs.c math/newlib/w_hypot.c math/newlib/e_hypot.c math/newlib/e_sqrt.c math/newlib/sf_nextafter.c\
+      math/newlib/e_acos.c math/newlib/ef_acos.c math/newlib/ef_sqrt.c \
       math/newlib/wf_acos.c \
 	  math/log2.c math/log10.c math/modf.c math/pow.c math/sin.c \
 	  math/sinh.c math/round.c math/nearbyint.c math/nan.c \

--- a/mona/core/openssl-1.0.0c/crypto/bio/b_sock.c
+++ b/mona/core/openssl-1.0.0c/crypto/bio/b_sock.c
@@ -113,15 +113,6 @@ static struct ghbn_cache_st
 #endif
 
 #ifdef MONA
-struct  hostent {
-  char  *h_name;        /* official name of host */
-  char  **h_aliases;    /* alias list */
-  int   h_addrtype;     /* host address type */
-  int   h_length;       /* length of address */
-  char  **h_addr_list;  /* list of addresses from name server */
-#define h_addr  h_addr_list[0]  /* address, for backward compatiblity */
-  unsigned int unused;  /* SENS defines this as ttl */
-};
 
 struct hostent *gethostbyaddr(const void *addr,
                                      socklen_t len, int type)

--- a/mona/include/monalibc/unistd.h
+++ b/mona/include/monalibc/unistd.h
@@ -35,6 +35,15 @@
 extern "C" {
 #endif
 
+#ifndef __SIZE_TYPE__
+#define __SIZE_TYPE__ unsigned long
+#endif
+#ifndef __size_t_defined
+#define __size_t_defined
+typedef __SIZE_TYPE__ size_t;
+#endif
+
+
 int getopt(int argc, char * const argv[],
            const char *optstring);
 

--- a/mona/include/sys/types.h
+++ b/mona/include/sys/types.h
@@ -70,7 +70,10 @@ enum {
 #ifndef __SIZE_TYPE__
 #define __SIZE_TYPE__ unsigned long
 #endif
+#ifndef __size_t_defined
+#define __size_t_defined
 typedef __SIZE_TYPE__ size_t;
+#endif
 
 #ifndef __uint8_t_defined
 typedef unsigned char       uint8_t;


### PR DESCRIPTION
## mona/core/openssl-1.0.0c/crypto/bio/b_sock.c
- removed its own hostent definition. netdb.h has the definition now
## mona/core/monalibc/src.inc
- added missing file names. the files themselves were added in the recent commit but not used in build.
## mona/include/monalibc/unistd.h
- added size_t definition
## mona/include/sys/types.h
- added macros to avoid duplications of size_t definition
## contrib/Graphics/MesaDemos/samples/overlay.c
- removed a workaround which is no more needed. sys/types.h doesn't have the NORMAL definition now.
## contrib/Graphics/MesaDemos/samples/star.c
- ditto
## contrib/Net/curl/Makefile.mona
- added compile options to avoid Win32 dependencies
